### PR TITLE
Address kroo/reflex-clerk#9: ValueError: Invalid path

### DIFF
--- a/custom_components/reflex_clerk/lib/clerk_provider.py
+++ b/custom_components/reflex_clerk/lib/clerk_provider.py
@@ -244,6 +244,8 @@ class ClerkSessionSynchronizer(rx.Component):
         return addl_imports
 
     def add_custom_code(self) -> list[str]:
+        clerk_state_name = ClerkState.get_full_name()
+
         return [
             """
 function ClerkSessionSynchronizer({ children }) {
@@ -254,10 +256,10 @@ function ClerkSessionSynchronizer({ children }) {
       if (isLoaded && !!addEvents) {
         if (isSignedIn) {
           getToken().then(token => {
-            addEvents([Event("state.clerk_state.set_clerk_session", {token})])
+            addEvents([Event("%s.set_clerk_session", {token})])
           })
         } else {
-          addEvents([Event("state.clerk_state.clear_clerk_session")])
+          addEvents([Event("%s.clear_clerk_session")])
         }
       }
   }, [isSignedIn])      
@@ -266,7 +268,7 @@ function ClerkSessionSynchronizer({ children }) {
       <>{children}</>
   )
 }
-"""
+""" % (clerk_state_name, clerk_state_name)
         ]
 
 


### PR DESCRIPTION
0.5.7 changes the naming conventions for states, which were previously hardcoded into the SessionSynchronizer.  This change instead pulls the full name from the state class directly, which appears to work both pre and post-the naming convention change.