### PR TITLE
Allow Notion SSO and requesting OAuth Access Tokens

### DIFF
--- a/custom_components/reflex_clerk/clerk_client/clerk_client.py
+++ b/custom_components/reflex_clerk/clerk_client/clerk_client.py
@@ -168,6 +168,17 @@ class ClerkAPIClient(object):
         url = self._get_url(f"/users/{user_id}")
         response = requests.patch(url, headers=self.headers, json=data.dict())
         return self._handle_response(response, User)
+    
+    def get_user_oauth_access_token(self, user_id: str, provider: str) -> str:
+        url = self._get_url(f"/users/{user_id}/oauth_access_tokens/{provider}")
+        response = requests.get(url, headers=self.headers)
+        data = response.json()
+        if isinstance(data, list) and len(data) > 0:
+            for item in data:
+                if 'scopes' in item and len(item.get('scopes')) > 0:
+                    return item['token']
+        else:
+            raise ValueError("Invalid response format. Expected a non-empty list.")
 
 
 BASE_URL = "https://api.clerk.com/v1"

--- a/custom_components/reflex_clerk/clerk_client/clerk_response_models.py
+++ b/custom_components/reflex_clerk/clerk_client/clerk_response_models.py
@@ -46,6 +46,7 @@ class Verification(pydantic.BaseModel):
             "oauth_google", "oauth_mock", "admin",
             "phone_code", "email_code", "reset_password_email_code",
             "web3_metamask_signature", "from_oauth_google",
+            "oauth_notion", "from_oauth_notion"
         ]]
     status: Optional[Literal['unverified', 'verified', 'transferable', 'failed', 'expired']]
     nonce: Optional[str] = None
@@ -60,10 +61,10 @@ class IdentificationLink(pydantic.BaseModel):
     Represents a link between an email address or phone number and another identification type.
 
     Attributes:
-        type: One of "oauth_google", "oauth_mock", or "saml"
+        type: One of "oauth_google", "oauth_mock", "saml", or "oauth_notion"
         id: A unique identifier for this link.
     """
-    type: Literal["oauth_google", "oauth_mock", "saml"]
+    type: Literal["oauth_google", "oauth_mock", "saml", "oauth_notion"]
     id: str
 
 

--- a/custom_components/reflex_clerk/lib/clerk_provider.py
+++ b/custom_components/reflex_clerk/lib/clerk_provider.py
@@ -229,6 +229,27 @@ class ClerkState(rx.State):
             user = self.clerk_api_client.get_user(self.user_id)
             self.set_user(user)
 
+    async def get_oauth_access_token(self, provider: str) -> str:
+        """
+        Fetches the OAuth access token for the specified provider.
+
+        Args:
+            provider (str): The OAuth provider (e.g., 'oauth_notion')
+
+        Returns:
+            str: The OAuth access token
+
+        Raises:
+            ValueError: If the user is not authenticated or the token fetch fails
+        """
+        if not self.is_signed_in or not self.user_id:
+            raise ValueError("User is not authenticated")
+
+        try:
+            return self.clerk_api_client.get_user_oauth_access_token(self.user_id, provider)
+        except Exception as e:
+            raise ValueError(f"Failed to fetch OAuth token: {str(e)}")
+
 
 class ClerkSessionSynchronizer(rx.Component):
     """ClerkSessionSynchronizer component."""


### PR DESCRIPTION
## Today I tried setting up Notion SSO using reflex-clerk.
 As it seems, the only thing that was needed for that is in Commit 1.

## Commit 2 is meant for requesting OAuth access tokens.
I need this to get access to the users notion and e.g. create new pages.

The method `get_user_oauth_access_token` isn't clean at all, and it just happens to work with Notion on my machine:
- I don't use `self._handle_response` because I ran into parsing errors
- the weird iteration to look for scopes is also just there so that I could get it running
- I'm not sure what needs to be done to make requesting oauth access tokens more generic, as I guess all OAuth Providers handle it in a similar fashion.

I got it to work on my own machine with the following functions using the pypi package `notion_client`:
```
from notion_client import Client

async def fetch_notion_data(self):
        try:
            token = await self.get_oauth_access_token("oauth_notion")
            
            # Use the token to fetch data from Notion API
            # This is a placeholder and should be replaced with actual Notion API call
            notion_response = requests.get(
                "https://api.notion.com/v1/users",
                headers={
                    "Authorization": f"Bearer {token}",
                    "Notion-Version": "2022-06-28",
                }
            )
            notion_data = notion_response.json()
            print(notion_data)
        except Exception as e:
            print(e)

    async def create_notion_page(self):
        try:
            token = await self.get_oauth_access_token("oauth_notion")
            notion = Client(auth=token)
            
            parent_page = notion.search(query="OMG Is it the Notion API?!")
            # pprint(parent_page)
            parent_page_id = parent_page["results"][0]["id"]
            print(parent_page_id)

            new_page = notion.pages.create(
                parent={"page_id": parent_page_id},
                properties={
                    "title": [{"type": "text", "text": {"content": "New page created via API"}}]
                },
                children=[
                    {
                        "object": "block",
                        "type": "paragraph",
                        "paragraph": {
                            "rich_text": [{"type": "text", "text": {"content": "This is a paragraph created using the Notion API."}}]
                        }
                    },
                    {
                        "object": "block",
                        "type": "bulleted_list_item",
                        "bulleted_list_item": {
                            "rich_text": [{"type": "text", "text": {"content": "This is a bullet point."}}]
                        }
                    },
                    {
                        "object": "block",
                        "type": "to_do",
                        "to_do": {
                            "rich_text": [{"type": "text", "text": {"content": "This is a to-do item."}}],
                            "checked": False
                        }
                    }
                ]
            )

            print(new_page)
        except Exception as e:
            print(e)
```

To be able to actually write into the users Notion I couldn't use Clerks Dev Notion Integration but needed to create a **public** integration myself with write permissions:
![image](https://github.com/user-attachments/assets/2dfa2492-a9f7-4692-bd00-4e8445368832)
 
Then I filled in the Client ID and Secret in Clerk, and set the scopes to `read`, `insert` and `update`, and copied the `Authorized redirect URI ` back into the Notion Integration: 
![image](https://github.com/user-attachments/assets/24164459-3033-433f-97cd-1be2ff41e6b2)

With this whole setup I was able to create a new page under my parent page as shown above in the python code.

I'd be very happy if you could try it out yourself, improve the code and then release a new version 🙏
Thanks for maintaining this project so far @kroo !
