### PR TITLE
OrganizationSwitcher wrapper

### DIFF
--- a/custom_components/reflex_clerk/__init__.py
+++ b/custom_components/reflex_clerk/__init__.py
@@ -3,7 +3,7 @@ from .clerk_client.clerk_response_models import User
 from .lib.clerk_provider import ClerkState, clerk_provider
 from .lib.control import signed_in, signed_out, redirect_to_sign_in, redirect_to_sign_up, redirect_to_user_profile, \
     redirect_to_organization_profile, redirect_to_create_organization, multisession_app_support, clerk_loading, \
-    clerk_loaded, protect
+    clerk_loaded, organization_switcher, protect
 from .lib.reflex_clerk import install_signin_page, install_signup_page, install_pages
 from .lib.sign_in import sign_in, sign_in_button
 from .lib.sign_out import sign_out_button

--- a/custom_components/reflex_clerk/lib/control.py
+++ b/custom_components/reflex_clerk/lib/control.py
@@ -36,6 +36,16 @@ class ClerkLoading(rx.Component):
     tag = "ClerkLoading"
 
 
+class OrganizationSwitcher(rx.Component):
+    """OrganizationSwitcher component."""
+
+    # The React library to wrap.
+    library = "@clerk/clerk-react"
+
+    # The React component tag.
+    tag = "OrganizationSwitcher"
+
+
 class Protect(rx.Component):
     """Protect component."""
 
@@ -207,6 +217,19 @@ def clerk_loading(*children: rx.Component) -> ClerkLoading:
         A ClerkLoading component instance that can be rendered.
     """
     return ClerkLoading.create(*children)
+
+
+def organization_switcher(*children: rx.Component) -> OrganizationSwitcher:
+    """
+    The <OrganizationSwitcher> component allows a user to switch between their account types - their personal account and their joined organizations.
+
+    Args:
+        *children: Zero or more child components that will be rendered inside the OrganizationSwitcher component.
+
+    Returns:
+        A OrganizationSwitcher component instance that can be rendered.
+    """
+    return OrganizationSwitcher.create(*children)
 
 
 def protect(


### PR DESCRIPTION
I was struggling with this for a while - not being able to use something like:
```
  clerk.protect(
      rx.vstack(
          ....
      ),
      permission="org:app:admin",
   ```
   
which would not let anyone view the protected content (even if they did have the permissions). See identical issue mentioned [here](https://stackoverflow.com/questions/77404623/nextjs-clerk-organisation-wont-apply-on-user).

It turns out that the user needs to [switch organizations](https://clerk.com/docs/components/organization/organization-switcher) from their personal account to the organization which has the permissions, and this can only be done on the UI side of things. This wrapper allows the users to do so.